### PR TITLE
[feat, revamp]: ECDSA Signing algorithm with SECP256k1 curve

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,14 +8,14 @@ module.exports = {
         //         '^.+\\.tsx?$': 'ts-jest',
         //     },
         // },
-        {
-            displayName: 'moi-logic',
-            testEnvironment: 'ts-node',
-            testMatch: ['<rootDir>/packages/moi-logic/__tests__/*.test.ts'],
-            transform: {
-                '^.+\\.tsx?$': 'ts-jest',
-            },
-        },
+        // {
+        //     displayName: 'moi-logic',
+        //     testEnvironment: 'ts-node',
+        //     testMatch: ['<rootDir>/packages/moi-logic/__tests__/*.test.ts'],
+        //     transform: {
+        //         '^.+\\.tsx?$': 'ts-jest',
+        //     },
+        // },
         // {
         //     displayName: 'moi-core',
         //     testEnvironment: 'ts-node',
@@ -32,6 +32,14 @@ module.exports = {
         //         '^.+\\.tsx?$': 'ts-jest',
         //     },
         // }
+        {
+            displayName: 'moi-signer',
+            testEnvironment: 'ts-node',
+            testMatch: ['<rootDir>/packages/moi-signer/__tests__/*.test.ts'],
+            transform: {
+                '^.+\\.tsx?$': 'ts-jest',
+            },
+        },
     ],
     testTimeout: 700000,
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "elliptic": "^6.5.4",
     "hdkey": "^2.1.0",
     "tiny-secp256k1": "^2.2.1",
-    "websocket": "^1.0.34"
+    "websocket": "^1.0.34",
+    "bitcoinjs-lib": "^4.0.2",
+    "blake2b": "^2.1.4"
   }
 }

--- a/packages/moi-signer/__tests__/ecdsa.test.ts
+++ b/packages/moi-signer/__tests__/ecdsa.test.ts
@@ -1,0 +1,17 @@
+import { Wallet } from "moi-wallet";
+import { Signer } from "../src";
+
+describe("Test ECDSA Signing with SECP256k1 Curve", () => {
+    describe("Signing raw message", () => {
+        it("should signing the message `hello, world`", async() => {
+            const __vault = new Wallet();
+            await __vault.fromMnemonic("unlock element young void mass casino suffer twin earth drill aerobic tooth", undefined);
+            
+            const _signer = new Signer(__vault);
+            const _message = Buffer.from("hello, world");
+            const _signature = _signer.sign(_message, _signer.signingAlgorithms["ecdsa_secp256k1"]);
+
+            expect(_signature).toBe("01473045022100acbfe695e7dbd3c5361238478327813b01feda3a9e7e7ca2867ab873f4444d20022079f41e1cf3fc2816fbb194186162c800dffc041a4eef9a8ba9b1f3c3ff2e399f");
+        })
+    })
+})

--- a/packages/moi-signer/src/ecdsa.ts
+++ b/packages/moi-signer/src/ecdsa.ts
@@ -1,15 +1,46 @@
-import {Wallet} from "moi-wallet";
-import elliptic from "elliptic";
+import { Wallet } from "moi-wallet";
+import { SigType } from "../types";
+import { ECPair, script, Transaction, networks } from "bitcoinjs-lib";
+import Blake2b from "blake2b";
 
-const secp256k1Curve = new elliptic.ec('secp256k1');
+export default class ECDSA_S256 implements SigType {
+    prefix: number;
+    sigName: string;
+    constructor() {
+        this.prefix = 1;
+        this.sigName = "ECDSA_S256";
+    }
 
-export const sign = (message: Buffer, vault: Wallet): string => {
-    let prvKey = secp256k1Curve.keyFromPrivate(vault.privateKey())
-    return prvKey.sign(message).toDER("hex");
-}
+    sign(message: Buffer, vault: Wallet): String {
+        let signingKey = vault.privateKey();
+        let _signingKey: Buffer
+        if(typeof signingKey === "string") {
+            _signingKey = Buffer.from(signingKey, 'hex');
+        }else {
+            _signingKey = signingKey
+        }
+        
+        // Hashing raw message with blake2b to get 32 bytes digest 
+        const messageHash = Blake2b(256 / 8).update(message).digest();
+        
+        const keyPair = ECPair.fromPrivateKey(_signingKey, { network: networks.bitcoin });
+        let signature = script.signature.encode(
+          keyPair.sign(messageHash),
+          Transaction.SIGHASH_ALL
+        );
+                     
+        // Removing last byte, since it's always 0x01 because of SIGHASH_ALL instruction
+        signature = signature.slice(0, signature.length - 1);
+        
+        const prefixArray = new Uint8Array(2);
+        prefixArray[0] = this.prefix;
+        prefixArray[1] = signature.length;
 
-
-export const verify = (message: Buffer, signature: string, pub: Buffer): boolean => {
-    let pubKey = secp256k1Curve.keyFromPublic(pub);
-    return pubKey.verify(message, signature)
+        const finalSigBytes = Buffer.concat([Buffer.from(prefixArray), signature]);
+        return finalSigBytes.toString('hex');
+    }
+    verify(): Boolean {
+        // yet to implement
+        return true
+    }
 }

--- a/packages/moi-signer/src/signer.ts
+++ b/packages/moi-signer/src/signer.ts
@@ -1,22 +1,40 @@
 /*
     This module/directory is responsible for handling 
-    cryptographic activity like signing, encryption/Decryption, verification etc
+    cryptographic activity like signing and verification 
+    using different Curves and Algorithms
 */
-import * as ecdsa from "./ecdsa"
-import {Wallet} from "moi-wallet"
+import ECDSA_S256 from "./ecdsa"
+import { SigType } from "../types"
+import { Wallet } from "moi-wallet"
 
 export class Signer {
     private signingVault: Wallet
+    signingAlgorithms: any
 
     constructor(vault: Wallet) {
         this.signingVault = vault
+        this.signingAlgorithms = {
+            "ecdsa_secp256k1" : new ECDSA_S256()
+        }
     }
 
-    public sign(message: Buffer): String {
-        return ecdsa.sign(message, this.signingVault)
+    public sign(message: Buffer, sigAlgo: SigType): String {
+        if(sigAlgo) {
+            switch(sigAlgo.sigName) {
+                case "ECDSA_S256": {
+                    const _sig = this.signingAlgorithms["ecdsa_secp256k1"];
+                    return _sig.sign(message, this.signingVault);
+                }
+                default: {
+                    throw new Error("invalid signature type")
+                }
+            }
+        }
+        throw new Error("signature type cannot be undefiend")
     }
 
     public verify(message: Buffer, signature: string): boolean {
-        return ecdsa.verify(message, signature, this.signingVault.publicKey())
+        // yet to implement
+        return true
     }
 }

--- a/packages/moi-signer/types/index.d.ts
+++ b/packages/moi-signer/types/index.d.ts
@@ -1,2 +1,7 @@
-export const ECDSA = "ecdsa"
-export const SCHNORR= "schnorr"
+import { Wallet } from "moi-wallet";
+export interface SigType {
+    prefix: number;
+    sigName: String;
+    sign(message: Buffer, vault: Wallet): String
+    verify(): Boolean
+}

--- a/packages/moi-wallet/src/wallet.ts
+++ b/packages/moi-wallet/src/wallet.ts
@@ -5,7 +5,7 @@
 
 import * as bip39 from 'bip39';
 import elliptic from 'elliptic';
-import {HDNode} from "moi-hdnode";
+import { HDNode } from "moi-hdnode";
 import { randomBytes } from 'crypto';
 
 /* Internal imports */


### PR DESCRIPTION
This PR will change ECDSA Signature and verification to use
1. RFC6979 for deterministic nonce while signing 
2. Blake2b for hashing the raw message during signing and verification
3. High level functions `Sign` and `Verify` functions at `moi-signer/src/signer.ts`
4. New type `SigType` to differentiate multiple signature algorithms which is inspired from backend.
5. Added `moi-signer/__tests__/ecdsa.test.ts` only for now.
