### PR TITLE
fix: signature verification irrespective of parity byte in publicKey

### DIFF
--- a/packages/moi-signer/__tests__/ecdsa.test.ts
+++ b/packages/moi-signer/__tests__/ecdsa.test.ts
@@ -3,7 +3,7 @@ import { Signer } from "../src";
 
 describe("Test ECDSA Signing and verification with SECP256k1 Curve", () => {
     const sampleMnemonic = "unlock element young void mass casino suffer twin earth drill aerobic tooth"
-    const smapleSig = "01473045022100acbfe695e7dbd3c5361238478327813b01feda3a9e7e7ca2867ab873f4444d20022079f41e1cf3fc2816fbb194186162c800dffc041a4eef9a8ba9b1f3c3ff2e399f";
+    const smapleSig = "01473045022100acbfe695e7dbd3c5361238478327813b01feda3a9e7e7ca2867ab873f4444d20022079f41e1cf3fc2816fbb194186162c800dffc041a4eef9a8ba9b1f3c3ff2e399f03";
     const pubKey = "5f2c7306be02b16d0f1ae75ae3fdbedf10b970d98c7646ec5e9beaf325a2e004";
     const _message = Buffer.from("hello, world");
 

--- a/packages/moi-signer/src/ecdsa.ts
+++ b/packages/moi-signer/src/ecdsa.ts
@@ -1,17 +1,19 @@
 import { Wallet } from "moi-wallet";
 import { SigType } from "../types";
+import Signature from "./signature";
 import { ECPair, script, Transaction, networks } from "bitcoinjs-lib";
 import Blake2b from "blake2b";
 
 export default class ECDSA_S256 implements SigType {
     prefix: number;
     sigName: string;
+
     constructor() {
         this.prefix = 1;
         this.sigName = "ECDSA_S256";
     }
 
-    sign(message: Buffer, vault: Wallet): String {
+    sign(message: Buffer, vault: Wallet): Signature {
         let signingKey = vault.privateKey();
         let _signingKey: Buffer
         if(typeof signingKey === "string") {
@@ -36,17 +38,23 @@ export default class ECDSA_S256 implements SigType {
         prefixArray[0] = this.prefix;
         prefixArray[1] = signature.length;
 
-        const finalSigBytes = Buffer.concat([Buffer.from(prefixArray), signature]);
-        return finalSigBytes.toString('hex');
+        const sig = new Signature(Buffer.from(prefixArray), signature, Buffer.from([keyPair.publicKey[0]]), this.sigName);
+        return sig;
     }
-    verify(message: Buffer, signature: Buffer, publicKey: Buffer): Boolean {        
+
+    verify(message: Buffer, signature: Signature, publicKey: Buffer): Boolean {  
+
+        let verificationKey = Buffer.concat([signature.Extra(), publicKey])
+
+        let rawSignature = signature.Digest();
+        // Appending the byte that was removed at the time of signing      
         let sigComps = script.signature.decode(
-            Buffer.concat([signature, Buffer.from([0x01])])
+            Buffer.concat([rawSignature, Buffer.from([0x01])])
         );
 
         // Hashing raw message with blake2b to get 32 bytes digest 
         const messageHash = Blake2b(256 / 8).update(message).digest();
-        const parsedPubkey = ECPair.fromPublicKey(publicKey, { network: networks.bitcoin });
+        const parsedPubkey = ECPair.fromPublicKey(verificationKey, { network: networks.bitcoin });
 
         return parsedPubkey.verify(messageHash, sigComps.signature)
     }

--- a/packages/moi-signer/src/signature.ts
+++ b/packages/moi-signer/src/signature.ts
@@ -1,0 +1,60 @@
+export default class Signature {
+    private prefix: Buffer;
+    private digest: Buffer;
+    private extraData: Buffer;
+    private name: String
+
+    constructor(prefix?: Buffer, digest?: Buffer, extraData?: Buffer, signatureName?: String) {
+        this.prefix = prefix;
+        this.digest = digest;
+        this.extraData = extraData;
+        this.name = signatureName
+    }
+    
+    public UnMarshall(signature: Buffer | String) {
+        let sig: Buffer;
+        if(typeof signature === "string") {
+            sig = Buffer.from(signature, 'hex')
+        }else {
+            sig = Buffer.from(signature)
+        }
+
+        const sigLen = sig[1].valueOf();
+        this.prefix = sig.subarray(0,2);
+        this.digest = sig.subarray(2, 2+sigLen);
+        this.extraData = sig.subarray(2+sigLen)
+        this.name = this.getSignatureName(sig[0].valueOf())
+    }
+
+    public Digest(): Buffer {
+        return this.digest;
+    }
+
+    public SigByte(): number {
+        return this.prefix[0].valueOf();
+    }
+
+    public Name(): String {
+        return this.name;
+    }
+
+    public Extra(): Buffer {
+        return this.extraData;
+    }
+
+    public Serialize(): Buffer {
+        if(this.name == "") {
+            throw new Error("signature is not intialized");
+        }
+        const finalSigBytesWithoutExtra = Buffer.concat([Buffer.from(this.prefix), this.digest]);
+        const finalSigBytes = Buffer.concat([finalSigBytesWithoutExtra, this.extraData]);
+        return finalSigBytes;
+    }
+
+    private getSignatureName(sigIndex: number): String {
+        switch(sigIndex) {
+            case 1: return "ECDSA_S256"
+            default: return ""
+        }
+    }
+}

--- a/packages/moi-signer/types/index.d.ts
+++ b/packages/moi-signer/types/index.d.ts
@@ -1,7 +1,8 @@
 import { Wallet } from "moi-wallet";
+import Signature from "../src/signature";
 export interface SigType {
     prefix: number;
     sigName: String;
-    sign(message: Buffer, vault: Wallet): String
-    verify(message: Buffer, signature: Buffer, publicKey: Buffer): Boolean
+    sign(message: Buffer, vault: Wallet): Signature
+    verify(message: Buffer, signature: Signature, publicKey: Buffer): Boolean
 }


### PR DESCRIPTION
This PR fixes the problem with verification of signature whose publicKey's X co-ordinate sign is different from Y co-ordinate by setting a parity byte as ExtraData to Signature.

Along with below changes
- Now every SigType implemented Signature class will return `Signature` type for `sign()`
- `verify()` in SigType interface will take signature of type `Signature`