### PR TITLE
Copyright attribution for moi-bip39 package

### DIFF
--- a/packages/moi-bip39/src/_wordlists.ts
+++ b/packages/moi-bip39/src/_wordlists.ts
@@ -1,3 +1,15 @@
+/**
+ * This code is based on the bitcoinjs/bip39 by Wei Lu and Danieal Cousens
+ * Modifications have been made to adapt it to the needs of moi-bip39 
+ * including enhancements for browser compatibility and TypeScript conversion.
+ * 
+ * Original module available at: https://github.com/bitcoinjs/bip39
+ * Modified version available at: https://github.com/sarvalabs/moi.js/tree/main/packages/moi-bip39
+ * 
+ * Copyright (c) 2014, Wei Lu <luwei.here@gmail.com> and Daniel Cousens <email@dcousens.com>
+ * Repository ISC license details can be found at https://github.com/bitcoinjs/bip39/blob/master/LICENSE
+ * 
+ **/
 import czech from './wordlists/czech.json';
 import chinese_simplified from './wordlists/chinese_simplified.json';
 import chinese_traditional from './wordlists/chinese_traditional.json';

--- a/packages/moi-bip39/src/bip39.ts
+++ b/packages/moi-bip39/src/bip39.ts
@@ -1,3 +1,15 @@
+/**
+ * This code is based on the bitcoinjs/bip39 by Wei Lu and Danieal Cousens
+ * Modifications have been made to adapt it to the needs of moi-bip39 
+ * including enhancements for browser compatibility and TypeScript conversion.
+ * 
+ * Original module available at: https://github.com/bitcoinjs/bip39
+ * Modified version available at: https://github.com/sarvalabs/moi.js/tree/main/packages/moi-bip39
+ * 
+ * Copyright (c) 2014, Wei Lu <luwei.here@gmail.com> and Daniel Cousens <email@dcousens.com>
+ * Repository ISC license details can be found at https://github.com/bitcoinjs/bip39/blob/master/LICENSE
+ * 
+ **/
 import { Buffer } from "buffer";
 import { sha256 } from "@noble/hashes/sha256";
 import { sha512 } from "@noble/hashes/sha512";

--- a/packages/moi-bip39/src/index.ts
+++ b/packages/moi-bip39/src/index.ts
@@ -1,2 +1,14 @@
+/**
+ * This code is based on the bitcoinjs/bip39 by Wei Lu and Danieal Cousens
+ * Modifications have been made to adapt it to the needs of moi-bip39 
+ * including enhancements for browser compatibility and TypeScript conversion.
+ * 
+ * Original module available at: https://github.com/bitcoinjs/bip39
+ * Modified version available at: https://github.com/sarvalabs/moi.js/tree/main/packages/moi-bip39
+ * 
+ * Copyright (c) 2014, Wei Lu <luwei.here@gmail.com> and Daniel Cousens <email@dcousens.com>
+ * Repository ISC license details can be found at https://github.com/bitcoinjs/bip39/blob/master/LICENSE
+ * 
+ **/
 export * from "./bip39";
 export * from "./_wordlists";


### PR DESCRIPTION
## Description
This PR adds the copyright mentions and attributions to the authors of https://github.com/bitcoinjs/bip39 in `moi-bip39` package which is modified version to enhance browser compatibility and typescript conversion 