### PR TITLE
refactor: make signer optional in LogicDriver

### DIFF
--- a/docs/source/logic.rst
+++ b/docs/source/logic.rst
@@ -231,8 +231,13 @@ Functions
     const logicDriver = await getLogicDriver(logicId, wallet);
 
 .. warning::
-    When the logic driver is initialized using a specific provider,
-    attempting to invoke a mutating routine will result in the SDK throwing an exception.
+    When the logic driver is initialized with a provider,
+    any attempt to execute a mutating routine will trigger the SDK to
+    raise an exception. The error message associated with this exception
+    will state: **"Mutating routine calls require a signer to be initialized"**.
+    Developers should ensure they should pass signer instance while
+    doing mutating routine calls to avoid encountering this exception.
+
 
 Usage
 ~~~~~

--- a/docs/source/logic.rst
+++ b/docs/source/logic.rst
@@ -230,6 +230,10 @@ Functions
     const wallet = await initWallet();
     const logicDriver = await getLogicDriver(logicId, wallet);
 
+.. warning::
+    When the logic driver is initialized using a specific provider,
+    attempting to invoke a mutating routine will result in the SDK throwing an exception.
+
 Usage
 ~~~~~
 

--- a/packages/js-moi-logic/__tests__/logic.test.ts
+++ b/packages/js-moi-logic/__tests__/logic.test.ts
@@ -7,7 +7,7 @@ import { LogicFactory } from "../src/logic-factory";
 import manifest from "../manifests/erc20.json";
 
 const HOST = "http://localhost:1600/";
-const MNEMONIC = "main story burst wonder sausage spice okay pioneer person unaware force bubble";
+const MNEMONIC = "visa security tobacco hood forget rate exhibit habit deny good sister slender";
 const INITIAL_SUPPLY = 100000000;
 const SYMBOL = "MOI";
 const RECEIVER = "0x4cdc9a1430ca00cbaaab5dcd858236ba75e64b863d69fa799d31854e103ddf72";
@@ -142,6 +142,56 @@ describe("Logic", () => {
                 expect(error.message).toBe("insufficient balance for sender");
                 expect(error.params.receipt).toBeDefined();
             }
+        });
+
+        it("should be able to read from persistent storage", async () => {
+            const symbol = await logic.persistentState.get("symbol");
+    
+            expect(symbol).toBe(SYMBOL);
+        });
+
+        it("should throw error when reading from persistent storage with invalid key", async () => {
+            const invalidKey = "invalid-key";
+            
+            expect(async () => {
+                await logic.persistentState.get(invalidKey);
+            }).rejects.toThrow(`The provided slot "${invalidKey}" does not exist.`);
+        });
+    });
+
+    describe("logic driver initialized using provider", () => {
+        let logic: LogicDriver;
+
+        beforeAll(async () => {
+            if(logicId == null) {
+                expect(logicId).toBeDefined();
+                return;
+            };
+
+            logic = await getLogicDriver(logicId, PROVIDER);
+        });
+
+        it("should able to retrieve balance of the account", async () => {
+            const { balance } = await logic.routines.BalanceOf(wallet.getAddress());
+            
+            expect(balance).toBeGreaterThan(0);
+        });
+
+        it("should return object when multiple values are returned", async () => {
+            const values = await logic.routines.DoubleReturnValue(wallet.getAddress());
+            const { symbol, supply } = values;
+
+            expect(values).toBeDefined();
+            expect(typeof symbol).toBe('string');
+            expect(typeof supply).toBe('number');
+        });
+
+        it("should thrown exception in mutating routine call", async () => {
+            const amount = Math.floor(Math.random() * 1000);
+            
+            expect(async () => {
+                await logic.routines.Transfer(RECEIVER, amount);
+            }).rejects.toThrow("Mutating routine calls require a signer to be initialized.");
         });
 
         it("should be able to read from persistent storage", async () => {

--- a/packages/js-moi-logic/__tests__/logic.test.ts
+++ b/packages/js-moi-logic/__tests__/logic.test.ts
@@ -179,14 +179,16 @@ describe("Logic", () => {
 
         it("should return object when multiple values are returned", async () => {
             const values = await logic.routines.DoubleReturnValue(wallet.getAddress());
+            
+            expect(values).toBeDefined();
+
             const { symbol, supply } = values;
 
-            expect(values).toBeDefined();
             expect(typeof symbol).toBe('string');
             expect(typeof supply).toBe('number');
         });
 
-        it("should thrown exception in mutating routine call", async () => {
+        it("should throw an exception in mutating routine call", async () => {
             const amount = Math.floor(Math.random() * 1000);
             
             expect(async () => {
@@ -200,7 +202,7 @@ describe("Logic", () => {
             expect(symbol).toBe(SYMBOL);
         });
 
-        it("should throw error when reading from persistent storage with invalid key", async () => {
+        it("should throw an exception when reading from persistent storage with invalid key", async () => {
             const invalidKey = "invalid-key";
             
             expect(async () => {

--- a/packages/js-moi-logic/dist/logic-base.d.ts
+++ b/packages/js-moi-logic/dist/logic-base.d.ts
@@ -1,5 +1,6 @@
 import { LogicManifest, ManifestCoder } from "js-moi-manifest";
-import { InteractionCallResponse, InteractionResponse, LogicPayload, type AbstractProvider } from "js-moi-providers";
+import type { AbstractProvider } from "js-moi-providers";
+import { InteractionCallResponse, InteractionResponse, LogicPayload } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { IxType } from "js-moi-utils";
 import { LogicIxArguments, LogicIxObject, LogicIxResponse } from "../types/interaction";

--- a/packages/js-moi-logic/dist/logic-base.d.ts
+++ b/packages/js-moi-logic/dist/logic-base.d.ts
@@ -1,5 +1,5 @@
 import { LogicManifest, ManifestCoder } from "js-moi-manifest";
-import { InteractionCallResponse, InteractionResponse, LogicPayload } from "js-moi-providers";
+import { InteractionCallResponse, InteractionResponse, LogicPayload, type AbstractProvider } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { IxType } from "js-moi-utils";
 import { LogicIxArguments, LogicIxObject, LogicIxResponse } from "../types/interaction";
@@ -7,13 +7,14 @@ import { LogicIxRequest, RoutineOption } from "../types/logic";
 import ElementDescriptor from "./element-descriptor";
 /**
  * This abstract class extends the ElementDescriptor class and serves as a base
- class for logic-related operations.
+ * class for logic-related operations.
  * It defines common properties and abstract methods that subclasses should implement.
  */
 export declare abstract class LogicBase extends ElementDescriptor {
-    protected signer: Signer;
+    protected signer?: Signer;
+    protected provider: AbstractProvider;
     protected manifestCoder: ManifestCoder;
-    constructor(manifest: LogicManifest.Manifest, signer: Signer);
+    constructor(manifest: LogicManifest.Manifest, arg: Signer | AbstractProvider);
     protected abstract createPayload(ixObject: LogicIxObject): LogicPayload;
     protected abstract getIxType(): IxType;
     protected abstract processResult(response: LogicIxResponse, timeout?: number): Promise<unknown | null>;
@@ -24,11 +25,11 @@ export declare abstract class LogicBase extends ElementDescriptor {
      */
     protected getLogicId(): string;
     /**
-     * Updates the signer or establishes a connection with a new signer.
+     * Updates the signer and provider instances for the LogicBase instance.
      *
-     * @param {Signer} signer -  The updated signer object or the new signer object to connect.
+     * @param {Signer | AbstractProvider} arg -  The signer or provider instance.
      */
-    connect(signer: Signer): void;
+    connect(arg: AbstractProvider | Signer): void;
     /**
      * Executes a routine with the given arguments and returns the interaction response.
      *

--- a/packages/js-moi-logic/dist/logic-descriptor.d.ts
+++ b/packages/js-moi-logic/dist/logic-descriptor.d.ts
@@ -1,4 +1,5 @@
 import { LogicManifest } from "js-moi-manifest";
+import type { AbstractProvider } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { LogicBase } from "./logic-base";
 import { LogicId } from "./logic-id";
@@ -17,7 +18,7 @@ export declare abstract class LogicDescriptor extends LogicBase {
     protected engine: EngineKind;
     protected sealed: boolean;
     protected assetLogic: boolean;
-    constructor(logicId: string, manifest: LogicManifest.Manifest, signer: Signer);
+    constructor(logicId: string, manifest: LogicManifest.Manifest, arg: Signer | AbstractProvider);
     /**
      * Returns the logic id of the logic.
      *

--- a/packages/js-moi-logic/dist/logic-descriptor.js
+++ b/packages/js-moi-logic/dist/logic-descriptor.js
@@ -21,8 +21,8 @@ class LogicDescriptor extends logic_base_1.LogicBase {
     engine;
     sealed;
     assetLogic;
-    constructor(logicId, manifest, signer) {
-        super(manifest, signer);
+    constructor(logicId, manifest, arg) {
+        super(manifest, arg);
         this.logicId = new logic_id_1.LogicId(logicId);
         this.manifest = manifest;
         this.encodedManifest = js_moi_manifest_1.ManifestCoder.encodeManifest(this.manifest);

--- a/packages/js-moi-logic/dist/logic-driver.d.ts
+++ b/packages/js-moi-logic/dist/logic-driver.d.ts
@@ -89,7 +89,7 @@ interface GetLogicDriver {
  * Returns a logic driver instance based on the given logic id.
  *
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer | AbstractProvider} signerOrProvider - The signer or provider instance.
+ * @param {Signer | AbstractProvider} signerOrProvider - The instance of the `Signer` or `AbstractProvider`.
  * @param {Options} options - The custom tesseract options for retrieving
  *
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.

--- a/packages/js-moi-logic/dist/logic-driver.d.ts
+++ b/packages/js-moi-logic/dist/logic-driver.d.ts
@@ -89,7 +89,7 @@ interface GetLogicDriver {
  * Returns a logic driver instance based on the given logic id.
  *
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer | AbstractProvider} value - The signer or provider instance.
+ * @param {Signer | AbstractProvider} signerOrProvider - The signer or provider instance.
  * @param {Options} options - The custom tesseract options for retrieving
  *
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.

--- a/packages/js-moi-logic/dist/logic-driver.d.ts
+++ b/packages/js-moi-logic/dist/logic-driver.d.ts
@@ -1,5 +1,5 @@
 import { LogicManifest } from "js-moi-manifest";
-import { LogicPayload, Options } from "js-moi-providers";
+import { LogicPayload, Options, type AbstractProvider } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { IxType } from "js-moi-utils";
 import { LogicIxObject, LogicIxResponse } from "../types/interaction";
@@ -14,6 +14,7 @@ export declare class LogicDriver<T extends Record<string, (...args: any) => any>
     readonly persistentState: PersistentState;
     readonly ephemeralState: EphemeralState;
     constructor(logicId: string, manifest: LogicManifest.Manifest, signer: Signer);
+    constructor(logicId: string, manifest: LogicManifest.Manifest, provider: AbstractProvider);
     /**
      * Creates the persistent and ephemeral states for the logic driver,
      if available in logic manifest.
@@ -61,13 +62,37 @@ export declare class LogicDriver<T extends Record<string, (...args: any) => any>
      */
     protected processResult(response: LogicIxResponse, timeout?: number): Promise<unknown | null>;
 }
+type LogicRoutines = Record<string, (...args: any) => any>;
+interface GetLogicDriver {
+    /**
+     * Returns a logic driver instance based on the given logic id.
+     *
+     * @param {string} logicId - The logic id of the logic.
+     * @param {Signer} signer - The signer instance.
+     * @param {Options} options - The custom tesseract options for retrieving
+     * logic manifest. (optional)
+     * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
+     */
+    <TLogic extends LogicRoutines>(logicId: string, signer: Signer, options?: Options): Promise<LogicDriver<TLogic>>;
+    /**
+     * Returns a logic driver instance based on the given logic id.
+     *
+     * @param {string} logicId - The logic id of the logic.
+     * @param {AbstractProvider} provider - The provider instance.
+     * @param {Options} options - The custom tesseract options for retrieving
+     * logic manifest. (optional)
+     * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
+     */
+    <TLogic extends LogicRoutines>(logicId: string, provider: AbstractProvider, options?: Options): Promise<LogicDriver<TLogic>>;
+}
 /**
  * Returns a logic driver instance based on the given logic id.
  *
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer} signer - The signer or provider instance.
+ * @param {Signer | AbstractProvider} value - The signer or provider instance.
  * @param {Options} options - The custom tesseract options for retrieving
- * logic manifest. (optional)
+ *
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
  */
-export declare const getLogicDriver: <T extends Record<string, (...args: any) => any>>(logicId: string, signer: Signer, options?: Options) => Promise<LogicDriver<T>>;
+export declare const getLogicDriver: GetLogicDriver;
+export {};

--- a/packages/js-moi-logic/dist/logic-driver.js
+++ b/packages/js-moi-logic/dist/logic-driver.js
@@ -139,7 +139,7 @@ exports.LogicDriver = LogicDriver;
  * Returns a logic driver instance based on the given logic id.
  *
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer | AbstractProvider} signerOrProvider - The signer or provider instance.
+ * @param {Signer | AbstractProvider} signerOrProvider - The instance of the `Signer` or `AbstractProvider`.
  * @param {Options} options - The custom tesseract options for retrieving
  *
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
@@ -150,6 +150,7 @@ const getLogicDriver = async (logicId, signerOrProvider, options) => {
     if (typeof manifest !== "object") {
         js_moi_utils_1.ErrorUtils.throwError("Invalid logic manifest", js_moi_utils_1.ErrorCode.INVALID_ARGUMENT);
     }
+    // below check added for type safety
     return signerOrProvider instanceof js_moi_signer_1.Signer
         ? new LogicDriver(logicId, manifest, signerOrProvider)
         : new LogicDriver(logicId, manifest, signerOrProvider);

--- a/packages/js-moi-logic/dist/logic-driver.js
+++ b/packages/js-moi-logic/dist/logic-driver.js
@@ -139,19 +139,19 @@ exports.LogicDriver = LogicDriver;
  * Returns a logic driver instance based on the given logic id.
  *
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer | AbstractProvider} value - The signer or provider instance.
+ * @param {Signer | AbstractProvider} signerOrProvider - The signer or provider instance.
  * @param {Options} options - The custom tesseract options for retrieving
  *
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
  */
-const getLogicDriver = async (logicId, value, options) => {
-    const provider = value instanceof js_moi_signer_1.Signer ? value.getProvider() : value;
+const getLogicDriver = async (logicId, signerOrProvider, options) => {
+    const provider = signerOrProvider instanceof js_moi_signer_1.Signer ? signerOrProvider.getProvider() : signerOrProvider;
     const manifest = await provider.getLogicManifest(logicId, "JSON", options);
     if (typeof manifest !== "object") {
         js_moi_utils_1.ErrorUtils.throwError("Invalid logic manifest", js_moi_utils_1.ErrorCode.INVALID_ARGUMENT);
     }
-    return value instanceof js_moi_signer_1.Signer
-        ? new LogicDriver(logicId, manifest, value)
-        : new LogicDriver(logicId, manifest, value);
+    return signerOrProvider instanceof js_moi_signer_1.Signer
+        ? new LogicDriver(logicId, manifest, signerOrProvider)
+        : new LogicDriver(logicId, manifest, signerOrProvider);
 };
 exports.getLogicDriver = getLogicDriver;

--- a/packages/js-moi-logic/dist/logic-driver.js
+++ b/packages/js-moi-logic/dist/logic-driver.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getLogicDriver = exports.LogicDriver = void 0;
+const js_moi_signer_1 = require("js-moi-signer");
 const js_moi_utils_1 = require("js-moi-utils");
 const logic_descriptor_1 = require("./logic-descriptor");
 const state_1 = require("./state");
@@ -11,8 +12,8 @@ class LogicDriver extends logic_descriptor_1.LogicDescriptor {
     routines = {};
     persistentState;
     ephemeralState;
-    constructor(logicId, manifest, signer) {
-        super(logicId, manifest, signer);
+    constructor(logicId, manifest, arg) {
+        super(logicId, manifest, arg);
         this.createState();
         this.createRoutines();
     }
@@ -23,7 +24,7 @@ class LogicDriver extends logic_descriptor_1.LogicDescriptor {
     createState() {
         const [persistentStatePtr, persistentStateExists] = this.hasPersistentState();
         if (persistentStateExists) {
-            const persistentState = new state_1.PersistentState(this.logicId.hex(), this.elements.get(persistentStatePtr), this.manifestCoder, this.signer.getProvider());
+            const persistentState = new state_1.PersistentState(this.logicId.hex(), this.elements.get(persistentStatePtr), this.manifestCoder, this.provider);
             (0, js_moi_utils_1.defineReadOnly)(this, "persistentState", persistentState);
         }
     }
@@ -138,22 +139,19 @@ exports.LogicDriver = LogicDriver;
  * Returns a logic driver instance based on the given logic id.
  *
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer} signer - The signer or provider instance.
+ * @param {Signer | AbstractProvider} value - The signer or provider instance.
  * @param {Options} options - The custom tesseract options for retrieving
- * logic manifest. (optional)
+ *
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
  */
-const getLogicDriver = async (logicId, signer, options) => {
-    try {
-        const provider = signer.getProvider();
-        const manifest = await provider.getLogicManifest(logicId, "JSON", options);
-        if (typeof manifest === "object") {
-            return new LogicDriver(logicId, manifest, signer);
-        }
+const getLogicDriver = async (logicId, value, options) => {
+    const provider = value instanceof js_moi_signer_1.Signer ? value.getProvider() : value;
+    const manifest = await provider.getLogicManifest(logicId, "JSON", options);
+    if (typeof manifest !== "object") {
         js_moi_utils_1.ErrorUtils.throwError("Invalid logic manifest", js_moi_utils_1.ErrorCode.INVALID_ARGUMENT);
     }
-    catch (err) {
-        throw err;
-    }
+    return value instanceof js_moi_signer_1.Signer
+        ? new LogicDriver(logicId, manifest, value)
+        : new LogicDriver(logicId, manifest, value);
 };
 exports.getLogicDriver = getLogicDriver;

--- a/packages/js-moi-logic/src/logic-base.ts
+++ b/packages/js-moi-logic/src/logic-base.ts
@@ -1,5 +1,5 @@
 import { LogicManifest, ManifestCoder } from "js-moi-manifest";
-import { CallorEstimateIxObject, InteractionCallResponse, InteractionObject, InteractionResponse, LogicPayload } from "js-moi-providers";
+import { CallorEstimateIxObject, InteractionCallResponse, InteractionObject, InteractionResponse, LogicPayload, type AbstractProvider } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { ErrorCode, ErrorUtils, IxType } from "js-moi-utils";
 import { LogicIxArguments, LogicIxObject, LogicIxResponse } from "../types/interaction";
@@ -7,22 +7,22 @@ import { LogicIxRequest, RoutineOption } from "../types/logic";
 import ElementDescriptor from "./element-descriptor";
 
 const DEFAULT_FUEL_PRICE = 1;
-const DEFAULT_FUEL_LIMIT = 5000;
 
 /**
  * This abstract class extends the ElementDescriptor class and serves as a base 
- class for logic-related operations.
+ * class for logic-related operations.
  * It defines common properties and abstract methods that subclasses should implement.
  */
 export abstract class LogicBase extends ElementDescriptor {
-    protected signer: Signer;
+    protected signer?: Signer;
+    protected provider: AbstractProvider;
     protected manifestCoder: ManifestCoder;
 
-    constructor(manifest: LogicManifest.Manifest, signer: Signer) {
+    constructor(manifest: LogicManifest.Manifest, arg: Signer | AbstractProvider) {
         super(manifest.elements)
 
         this.manifestCoder = new ManifestCoder(this.elements, this.classDefs)
-        this.signer = signer;
+        this.connect(arg)
     }
 
     // abstract methods to be implemented by subclasses
@@ -43,12 +43,17 @@ export abstract class LogicBase extends ElementDescriptor {
     }
 
     /**
-     * Updates the signer or establishes a connection with a new signer.
+     * Updates the signer and provider instances for the LogicBase instance.
      * 
-     * @param {Signer} signer -  The updated signer object or the new signer object to connect.
+     * @param {Signer | AbstractProvider} arg -  The signer or provider instance.
      */
-    public connect(signer: Signer): void {
-        this.signer = signer;
+    public connect(arg: AbstractProvider | Signer): void {
+        if (arg instanceof Signer) {
+            this.signer = arg;
+            this.provider = arg.getProvider();
+            return;
+        }
+        this.provider = arg;
     }
 
     /**
@@ -71,10 +76,10 @@ export abstract class LogicBase extends ElementDescriptor {
         }
 
         const { type, params } = this.processArguments(ixObject, method, option);
-     
+
         switch (type) {
             case "call": {
-                const response = await this.signer.call(params as CallorEstimateIxObject);
+                const response = await this.provider.call(params as CallorEstimateIxObject);
 
                 return {
                     ...response,
@@ -85,9 +90,23 @@ export abstract class LogicBase extends ElementDescriptor {
                 };
             }
             case "estimate": {
-                return this.signer.estimateFuel(params as CallorEstimateIxObject);
+                if (!this.signer?.isInitialized()) {
+                    ErrorUtils.throwError(
+                        "Mutating routine calls require a signer to be initialized.",
+                        ErrorCode.NOT_INITIALIZED
+                    );
+                }
+                
+                return this.provider.estimateFuel(params as CallorEstimateIxObject);
             }
             case "send": {
+                if (!this.signer?.isInitialized()) {
+                    ErrorUtils.throwError(
+                        "Mutating routine calls require a signer to be initialized.",
+                        ErrorCode.NOT_INITIALIZED
+                    );
+                }
+
                 const response = await this.signer.sendInteraction(params);
 
                 return {
@@ -175,9 +194,6 @@ export abstract class LogicBase extends ElementDescriptor {
         } as LogicIxObject
 
         ixObject.call = async (): Promise<InteractionCallResponse> => {
-            option.fuelLimit = option.fuelLimit != null ? option.fuelLimit : await ixObject.estimateFuel();
-            option.fuelPrice = option.fuelPrice != null ? option.fuelPrice : DEFAULT_FUEL_PRICE;
-
             return this.executeRoutine(ixObject, "call", option) as Promise<InteractionCallResponse>
         }
 
@@ -189,9 +205,6 @@ export abstract class LogicBase extends ElementDescriptor {
         }
         
         ixObject.estimateFuel = (): Promise<number|bigint> => {
-            option.fuelLimit = option.fuelLimit != null ? option.fuelLimit : DEFAULT_FUEL_LIMIT;
-            option.fuelPrice = option.fuelPrice != null ? option.fuelPrice : DEFAULT_FUEL_PRICE;
-
             return this.executeRoutine(ixObject, "estimate", option) as Promise<number | bigint>
         }
 

--- a/packages/js-moi-logic/src/logic-base.ts
+++ b/packages/js-moi-logic/src/logic-base.ts
@@ -1,5 +1,6 @@
 import { LogicManifest, ManifestCoder } from "js-moi-manifest";
-import { CallorEstimateIxObject, InteractionCallResponse, InteractionObject, InteractionResponse, LogicPayload, type AbstractProvider } from "js-moi-providers";
+import type { AbstractProvider } from "js-moi-providers";
+import { CallorEstimateIxObject, InteractionCallResponse, InteractionObject, InteractionResponse, LogicPayload } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { ErrorCode, ErrorUtils, IxType } from "js-moi-utils";
 import { LogicIxArguments, LogicIxObject, LogicIxResponse } from "../types/interaction";

--- a/packages/js-moi-logic/src/logic-descriptor.ts
+++ b/packages/js-moi-logic/src/logic-descriptor.ts
@@ -1,4 +1,5 @@
 import { LogicManifest, ManifestCoder } from "js-moi-manifest";
+import type { AbstractProvider } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { LogicBase } from "./logic-base";
 import { LogicId } from "./logic-id";
@@ -21,8 +22,8 @@ export abstract class LogicDescriptor extends LogicBase {
     protected sealed: boolean;
     protected assetLogic: boolean;
 
-    constructor(logicId: string, manifest: LogicManifest.Manifest, signer: Signer) {
-        super(manifest, signer)
+    constructor(logicId: string, manifest: LogicManifest.Manifest, arg: Signer | AbstractProvider) {
+        super(manifest, arg)
         this.logicId = new LogicId(logicId);
         this.manifest = manifest;
         this.encodedManifest = ManifestCoder.encodeManifest(this.manifest);

--- a/packages/js-moi-logic/src/logic-driver.ts
+++ b/packages/js-moi-logic/src/logic-driver.ts
@@ -16,7 +16,7 @@ export class LogicDriver<T extends Record<string, (...args: any) => any> = any> 
     public readonly ephemeralState: EphemeralState;
 
     constructor(logicId: string, manifest: LogicManifest.Manifest, signer: Signer);
-    constructor(logicId: string, manifest: LogicManifest.Manifest, provider: AbstractProvider)
+    constructor(logicId: string, manifest: LogicManifest.Manifest, provider: AbstractProvider);
     constructor(logicId: string, manifest: LogicManifest.Manifest, arg: Signer | AbstractProvider) {
         super(logicId, manifest, arg)
         this.createState();
@@ -207,7 +207,7 @@ interface GetLogicDriver {
  * Returns a logic driver instance based on the given logic id.
  * 
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer | AbstractProvider} signerOrProvider - The signer or provider instance.
+ * @param {Signer | AbstractProvider} signerOrProvider - The instance of the `Signer` or `AbstractProvider`.
  * @param {Options} options - The custom tesseract options for retrieving
  * 
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
@@ -223,6 +223,7 @@ export const getLogicDriver: GetLogicDriver = async <T extends Record<string, (.
         );
     }
 
+    // below check added for type safety
     return signerOrProvider instanceof Signer 
         ? new LogicDriver<T>(logicId, manifest, signerOrProvider)
         : new LogicDriver<T>(logicId, manifest, signerOrProvider);

--- a/packages/js-moi-logic/src/logic-driver.ts
+++ b/packages/js-moi-logic/src/logic-driver.ts
@@ -207,13 +207,13 @@ interface GetLogicDriver {
  * Returns a logic driver instance based on the given logic id.
  * 
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer | AbstractProvider} value - The signer or provider instance.
+ * @param {Signer | AbstractProvider} signerOrProvider - The signer or provider instance.
  * @param {Options} options - The custom tesseract options for retrieving
  * 
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
  */
-export const getLogicDriver: GetLogicDriver = async <T extends Record<string, (...args: any) => any>>(logicId: string, value: Signer | AbstractProvider, options?: Options): Promise<LogicDriver<T>> => {
-    const provider = value instanceof Signer ? value.getProvider() : value;
+export const getLogicDriver: GetLogicDriver = async <T extends Record<string, (...args: any) => any>>(logicId: string, signerOrProvider: Signer | AbstractProvider, options?: Options): Promise<LogicDriver<T>> => {
+    const provider = signerOrProvider instanceof Signer ? signerOrProvider.getProvider() : signerOrProvider;
     const manifest = await provider.getLogicManifest(logicId, "JSON", options);
 
     if (typeof manifest !== "object") {
@@ -223,7 +223,7 @@ export const getLogicDriver: GetLogicDriver = async <T extends Record<string, (.
         );
     }
 
-    return value instanceof Signer 
-        ? new LogicDriver<T>(logicId, manifest, value)
-        : new LogicDriver<T>(logicId, manifest, value);
+    return signerOrProvider instanceof Signer 
+        ? new LogicDriver<T>(logicId, manifest, signerOrProvider)
+        : new LogicDriver<T>(logicId, manifest, signerOrProvider);
 }

--- a/packages/js-moi-logic/src/logic-driver.ts
+++ b/packages/js-moi-logic/src/logic-driver.ts
@@ -1,5 +1,5 @@
 import { LogicManifest } from "js-moi-manifest";
-import { LogicPayload, Options } from "js-moi-providers";
+import { LogicPayload, Options, type AbstractProvider } from "js-moi-providers";
 import { Signer } from "js-moi-signer";
 import { ErrorCode, ErrorUtils, IxType, defineReadOnly, hexToBytes } from "js-moi-utils";
 import { LogicIxObject, LogicIxResponse } from "../types/interaction";
@@ -15,8 +15,10 @@ export class LogicDriver<T extends Record<string, (...args: any) => any> = any> 
     public readonly persistentState: PersistentState;
     public readonly ephemeralState: EphemeralState;
 
-    constructor(logicId: string, manifest: LogicManifest.Manifest, signer: Signer) {
-        super(logicId, manifest, signer)
+    constructor(logicId: string, manifest: LogicManifest.Manifest, signer: Signer);
+    constructor(logicId: string, manifest: LogicManifest.Manifest, provider: AbstractProvider)
+    constructor(logicId: string, manifest: LogicManifest.Manifest, arg: Signer | AbstractProvider) {
+        super(logicId, manifest, arg)
         this.createState();
         this.createRoutines();
     }
@@ -33,7 +35,7 @@ export class LogicDriver<T extends Record<string, (...args: any) => any> = any> 
                 this.logicId.hex(),
                 this.elements.get(persistentStatePtr),
                 this.manifestCoder,
-                this.signer.getProvider()
+                this.provider
             )
 
             defineReadOnly(this, "persistentState", persistentState)
@@ -175,29 +177,53 @@ export class LogicDriver<T extends Record<string, (...args: any) => any> = any> 
     }
 }
 
+type LogicRoutines = Record<string, (...args: any) => any>;
+
+interface GetLogicDriver {
+    /**
+     * Returns a logic driver instance based on the given logic id.
+     * 
+     * @param {string} logicId - The logic id of the logic.
+     * @param {Signer} signer - The signer instance. 
+     * @param {Options} options - The custom tesseract options for retrieving 
+     * logic manifest. (optional)
+     * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
+     */
+    <TLogic extends LogicRoutines>(logicId: string, signer: Signer, options?: Options): Promise<LogicDriver<TLogic>>;
+
+    /**
+     * Returns a logic driver instance based on the given logic id.
+     * 
+     * @param {string} logicId - The logic id of the logic.
+     * @param {AbstractProvider} provider - The provider instance.
+     * @param {Options} options - The custom tesseract options for retrieving 
+     * logic manifest. (optional)
+     * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
+     */
+    <TLogic extends LogicRoutines>(logicId: string, provider: AbstractProvider, options?: Options): Promise<LogicDriver<TLogic>>;
+}
+
 /**
  * Returns a logic driver instance based on the given logic id.
  * 
  * @param {string} logicId - The logic id of the logic.
- * @param {Signer} signer - The signer or provider instance. 
- * @param {Options} options - The custom tesseract options for retrieving 
- * logic manifest. (optional)
+ * @param {Signer | AbstractProvider} value - The signer or provider instance.
+ * @param {Options} options - The custom tesseract options for retrieving
+ * 
  * @returns {Promise<LogicDriver>} A promise that resolves to a LogicDriver instance.
  */
-export const getLogicDriver = async <T extends Record<string, (...args: any) => any>>(logicId: string, signer: Signer, options?: Options): Promise<LogicDriver<T>> => {
-    try {
-        const provider = signer.getProvider();
-        const manifest = await provider.getLogicManifest(logicId, "JSON", options);
+export const getLogicDriver: GetLogicDriver = async <T extends Record<string, (...args: any) => any>>(logicId: string, value: Signer | AbstractProvider, options?: Options): Promise<LogicDriver<T>> => {
+    const provider = value instanceof Signer ? value.getProvider() : value;
+    const manifest = await provider.getLogicManifest(logicId, "JSON", options);
 
-        if (typeof manifest === "object") {
-            return  new LogicDriver<T>(logicId, manifest, signer);
-        }
-
+    if (typeof manifest !== "object") {
         ErrorUtils.throwError(
             "Invalid logic manifest",
             ErrorCode.INVALID_ARGUMENT
         );
-    } catch(err) {
-        throw err;
     }
+
+    return value instanceof Signer 
+        ? new LogicDriver<T>(logicId, manifest, value)
+        : new LogicDriver<T>(logicId, manifest, value);
 }

--- a/packages/js-moi-providers/src/jsonrpc-provider.ts
+++ b/packages/js-moi-providers/src/jsonrpc-provider.ts
@@ -53,7 +53,7 @@ export class JsonRpcProvider extends BaseProvider {
                 jsonrpc: "2.0",
                 id: 1
             };
-            
+
             const response = await fetch(this.host, {
                 method: 'POST',
                 body: JSON.stringify(payload),

--- a/packages/js-moi-signer/dist/signer.d.ts
+++ b/packages/js-moi-signer/dist/signer.d.ts
@@ -34,8 +34,8 @@ export declare abstract class Signer {
     /**
      * Checks the validity of an interaction object by performing various checks.
      *
+     * @param {InteractionMethod} method - The method to be checked.
      * @param {InteractionObject} ixObject - The interaction object to be checked.
-     * @param {number | bigint} nonce - The nonce (interaction count) for comparison.
      * @throws {Error} if any of the checks fail, indicating an invalid interaction.
      */
     private checkInteraction;
@@ -43,6 +43,7 @@ export declare abstract class Signer {
      * Prepares the interaction object by populating necessary fields and
      * performing validity checks.
      *
+     * @param {InteractionMethod} method - The method to prepare the interaction for.
      * @param {InteractionObject} ixObject - The interaction object to prepare.
      * @returns {Promise<void>} A Promise that resolves once the preparation is complete.
      * @throws {Error} if the interaction object is not valid or if there is

--- a/packages/js-moi-signer/dist/signer.d.ts
+++ b/packages/js-moi-signer/dist/signer.d.ts
@@ -43,7 +43,7 @@ export declare abstract class Signer {
      * Prepares the interaction object by populating necessary fields and
      * performing validity checks.
      *
-     * @param {InteractionMethod} method - The method to prepare the interaction for.
+     * @param {InteractionMethod} method - The method for which the interaction is being prepared.
      * @param {InteractionObject} ixObject - The interaction object to prepare.
      * @returns {Promise<void>} A Promise that resolves once the preparation is complete.
      * @throws {Error} if the interaction object is not valid or if there is

--- a/packages/js-moi-signer/dist/signer.js
+++ b/packages/js-moi-signer/dist/signer.js
@@ -116,7 +116,7 @@ class Signer {
             ixObject.sender = this.getAddress();
         }
         await this.checkInteraction(method, ixObject);
-        if (ixObject.nonce == null) {
+        if (method === "send" && ixObject.nonce == null) {
             ixObject.nonce = await this.getNonce();
         }
     }

--- a/packages/js-moi-signer/dist/signer.js
+++ b/packages/js-moi-signer/dist/signer.js
@@ -93,11 +93,11 @@ class Signer {
             if (ixObject.fuel_price === 0) {
                 js_moi_utils_1.ErrorUtils.throwError("Invalid fuel price", js_moi_utils_1.ErrorCode.INTERACTION_UNDERPRICED);
             }
-        }
-        if (ixObject.nonce !== undefined || ixObject.nonce !== null) {
-            const nonce = await this.getNonce({ tesseract_number: -1 });
-            if (ixObject.nonce < nonce) {
-                js_moi_utils_1.ErrorUtils.throwError("Invalid nonce", js_moi_utils_1.ErrorCode.NONCE_EXPIRED);
+            if (ixObject.nonce != null) {
+                const nonce = await this.getNonce({ tesseract_number: -1 });
+                if (ixObject.nonce < nonce) {
+                    js_moi_utils_1.ErrorUtils.throwError("Invalid nonce", js_moi_utils_1.ErrorCode.NONCE_EXPIRED);
+                }
             }
         }
     }
@@ -105,7 +105,7 @@ class Signer {
      * Prepares the interaction object by populating necessary fields and
      * performing validity checks.
      *
-     * @param {InteractionMethod} method - The method to prepare the interaction for.
+     * @param {InteractionMethod} method - The method for which the interaction is being prepared.
      * @param {InteractionObject} ixObject - The interaction object to prepare.
      * @returns {Promise<void>} A Promise that resolves once the preparation is complete.
      * @throws {Error} if the interaction object is not valid or if there is

--- a/packages/js-moi-signer/src/signer.ts
+++ b/packages/js-moi-signer/src/signer.ts
@@ -143,7 +143,7 @@ export abstract class Signer {
         
         await this.checkInteraction(method, ixObject);
         
-        if (ixObject.nonce == null) {
+        if (method === "send" && ixObject.nonce == null) {
             ixObject.nonce = await this.getNonce();
         }
     }

--- a/packages/js-moi-signer/src/signer.ts
+++ b/packages/js-moi-signer/src/signer.ts
@@ -78,7 +78,7 @@ export abstract class Signer {
      * @throws {Error} if any of the checks fail, indicating an invalid interaction.
      */
     private async checkInteraction(method: InteractionMethod, ixObject: InteractionObject): Promise<void> {
-        if( ixObject.type == null) {
+        if(ixObject.type == null) {
             ErrorUtils.throwError("Interaction type is missing", ErrorCode.MISSING_ARGUMENT)
         }
 

--- a/packages/js-moi-signer/src/signer.ts
+++ b/packages/js-moi-signer/src/signer.ts
@@ -4,6 +4,8 @@ import { SigType, SigningAlgorithms } from "../types";
 import ECDSA_S256 from "./ecdsa";
 import Signature from "./signature";
 
+type InteractionMethod = "call" | "send" | "estimateFuel";
+
 /**
  * An abstract class representing a signer responsible for cryptographic 
  * activities like signing and verification.
@@ -71,21 +73,21 @@ export abstract class Signer {
     /**
      * Checks the validity of an interaction object by performing various checks.
      *
+     * @param {InteractionMethod} method - The method to be checked.
      * @param {InteractionObject} ixObject - The interaction object to be checked.
-     * @param {number | bigint} nonce - The nonce (interaction count) for comparison.
      * @throws {Error} if any of the checks fail, indicating an invalid interaction.
      */
-    private async checkInteraction(ixObject: InteractionObject): Promise<void> {
-        if(ixObject.type === undefined || ixObject.type === null) {
+    private async checkInteraction(method: InteractionMethod, ixObject: InteractionObject): Promise<void> {
+        if( ixObject.type == null) {
             ErrorUtils.throwError("Interaction type is missing", ErrorCode.MISSING_ARGUMENT)
-        }
-
-        if(!isValidAddress(ixObject.sender)) {
-            ErrorUtils.throwError("Invalid sender address", ErrorCode.INVALID_ARGUMENT);
         }
 
         if(ixObject.sender == null) {
             ErrorUtils.throwError("Sender address is missing", ErrorCode.MISSING_ARGUMENT);
+        }
+
+        if(!isValidAddress(ixObject.sender)) {
+            ErrorUtils.throwError("Invalid sender address", ErrorCode.INVALID_ARGUMENT);
         }
 
         if(this.isInitialized() && ixObject.sender !== this.getAddress()) {
@@ -102,16 +104,18 @@ export abstract class Signer {
             }
         }
 
-        if(ixObject.fuel_price === undefined || ixObject.fuel_price === null) {
-            ErrorUtils.throwError("Fuel price is missing", ErrorCode.MISSING_ARGUMENT);
-        }
+        if (method === "send") {
+            if(ixObject.fuel_price == null) {
+                ErrorUtils.throwError("Fuel price is missing", ErrorCode.MISSING_ARGUMENT);
+            }
 
-        if(ixObject.fuel_limit === undefined || ixObject.fuel_limit === null) {
-            ErrorUtils.throwError("Fuel limit is missing", ErrorCode.MISSING_ARGUMENT);
-        }
+            if(ixObject.fuel_limit == null) {
+                ErrorUtils.throwError("Fuel limit is missing", ErrorCode.MISSING_ARGUMENT);
+            }
 
-        if(ixObject.fuel_limit === 0) {
-            ErrorUtils.throwError("Invalid fuel limit", ErrorCode.INTERACTION_UNDERPRICED);
+            if(ixObject.fuel_price === 0) {
+                ErrorUtils.throwError("Invalid fuel price", ErrorCode.INTERACTION_UNDERPRICED);
+            }
         }
 
         if(ixObject.nonce !== undefined || ixObject.nonce !== null) {
@@ -126,17 +130,18 @@ export abstract class Signer {
      * Prepares the interaction object by populating necessary fields and 
      * performing validity checks.
      *
+     * @param {InteractionMethod} method - The method to prepare the interaction for.
      * @param {InteractionObject} ixObject - The interaction object to prepare.
      * @returns {Promise<void>} A Promise that resolves once the preparation is complete.
      * @throws {Error} if the interaction object is not valid or if there is 
      * an error during preparation.
      */
-    private async prepareInteraction(ixObject: InteractionObject): Promise<void> {
+    private async prepareInteraction(method: InteractionMethod, ixObject: InteractionObject): Promise<void> {
         if (!ixObject.sender) {
             ixObject.sender = this.getAddress();
         }
         
-        await this.checkInteraction(ixObject);
+        await this.checkInteraction(method, ixObject);
         
         if (ixObject.nonce == null) {
             ixObject.nonce = await this.getNonce();
@@ -157,7 +162,7 @@ export abstract class Signer {
         // Get the provider
         const provider = this.getProvider();
 
-        await this.prepareInteraction(ixObject);
+        await this.prepareInteraction('call', ixObject);
 
         return await provider.call(ixObject as CallorEstimateIxObject)
     }
@@ -178,7 +183,7 @@ export abstract class Signer {
         // Get the provider
         const provider = this.getProvider();
 
-        await this.prepareInteraction(ixObject);
+        await this.prepareInteraction('estimateFuel', ixObject);
 
         return await provider.estimateFuel(ixObject as CallorEstimateIxObject)
     }
@@ -201,7 +206,7 @@ export abstract class Signer {
             // Get the signature algorithm
             const sigAlgo = this.signingAlgorithms["ecdsa_secp256k1"];
 
-            await this.prepareInteraction(ixObject);
+            await this.prepareInteraction('send', ixObject);
 
             // Sign the interaction object
             const ixRequest = this.signInteraction(ixObject, sigAlgo)

--- a/packages/js-moi-signer/src/signer.ts
+++ b/packages/js-moi-signer/src/signer.ts
@@ -116,12 +116,12 @@ export abstract class Signer {
             if(ixObject.fuel_price === 0) {
                 ErrorUtils.throwError("Invalid fuel price", ErrorCode.INTERACTION_UNDERPRICED);
             }
-        }
 
-        if(ixObject.nonce !== undefined || ixObject.nonce !== null) {
-            const nonce = await this.getNonce({ tesseract_number: -1 });
-            if(ixObject.nonce < nonce) {
-                ErrorUtils.throwError("Invalid nonce", ErrorCode.NONCE_EXPIRED);
+            if(ixObject.nonce != null) {
+                const nonce = await this.getNonce({ tesseract_number: -1 });
+                if(ixObject.nonce < nonce) {
+                    ErrorUtils.throwError("Invalid nonce", ErrorCode.NONCE_EXPIRED);
+                }
             }
         }
     }
@@ -130,7 +130,7 @@ export abstract class Signer {
      * Prepares the interaction object by populating necessary fields and 
      * performing validity checks.
      *
-     * @param {InteractionMethod} method - The method to prepare the interaction for.
+     * @param {InteractionMethod} method - The method for which the interaction is being prepared.
      * @param {InteractionObject} ixObject - The interaction object to prepare.
      * @returns {Promise<void>} A Promise that resolves once the preparation is complete.
      * @throws {Error} if the interaction object is not valid or if there is 


### PR DESCRIPTION
# Refactor Logic Driver Construction: Optional Signer Parameter

This pull request refactors the construction of the `LogicDriver` class by making the `Signer` instance optional. The changes apply to the `constructor` method and the `getLogicDriver` method.

## Changes

- **`constructor`**: The logic driver instance can now be created using an instance of `AbstractProvider` in addition to the existing `Signer` parameter.

- **`getLogicDriver`**: Similar to the constructor, the `Signer` instance is now optional, and an instance of `AbstractProvider` can be used for logic driver creation.

- **`Signer.connect`**: Now accepts an instance of either `Signer` or `AbstractProvider`. If a `Signer` instance is provided as an argument, it will extract and replace the `provider` property of `LogicDriver` with it. This modification enhances flexibility in connecting signers or providers seamlessly within the `Signer` class.

This approach aims to reduce complexity and make the logic driver initialization more accessible for developers.

- closes #53 

## Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist
- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have updated the README and other relevant documents (guides...)

